### PR TITLE
No evasive splitting

### DIFF
--- a/scripts/strike groups/sg_batch_dart.lua
+++ b/scripts/strike groups/sg_batch_dart.lua
@@ -16,7 +16,7 @@ LayoutMode = "Nodes"
 
 StanceGrouping = "Shape"
 StanceGroupingAg = "Shape"
-StanceGroupingEv = "Subs"
+StanceGroupingEv = "Shape"
 
 DeathDamage = 0.90
 FriendlyFire = { 0.8, 0.0, 0.0 }       -- Base, Pop, PopSqrt

--- a/scripts/strike groups/sg_batch_delta.lua
+++ b/scripts/strike groups/sg_batch_delta.lua
@@ -13,7 +13,7 @@ LayoutMode = "Nodes"
 
 StanceGrouping = "Shape"
 StanceGroupingAg = "Shape"
-StanceGroupingEv = "Subs"
+StanceGroupingEv = "Shape"
 
 DeathDamage = 0.85
 FriendlyFire = { 0.7, 0.0, 0.0 }       -- Base, Pop, PopSqrt

--- a/scripts/strike groups/sg_batch_wedge.lua
+++ b/scripts/strike groups/sg_batch_wedge.lua
@@ -16,7 +16,7 @@ LayoutMode = "Nodes"
 
 StanceGrouping = "Shape"
 StanceGroupingAg = "Shape"
-StanceGroupingEv = "Subs"
+StanceGroupingEv = "Shape"
 DeathDamage = 0.85
 FriendlyFire = { 0.7, 0.0, 0.0 }       -- Base, Pop, PopSqrt
 


### PR DESCRIPTION
- hiigaran 'batch delta' sg no longer splits in evasive (used by all fighter squadrons)
- vaygr 'batch dart' (scouts, acs, lances) and 'batch wedge' (bombers) no longer split in evasive