### PR TITLE
Emp tweaks

### DIFF
--- a/ship/hgn_attackbomber/hgn_attackbomber.ship
+++ b/ship/hgn_attackbomber/hgn_attackbomber.ship
@@ -171,7 +171,7 @@ StartShipWeaponConfig(NewShipType,"Hgn_AntiShipBombLauncher","Weapon_L","Weapon_
 StartShipWeaponConfig(NewShipType,"Hgn_AntiShipBombLauncher","Weapon_R","Weapon_R");
 StartShipWeaponConfig(NewShipType,"Hgn_AntiSubSystemBombLauncher","Weapon_L","Weapon_L");
 StartShipWeaponConfig(NewShipType,"Hgn_AntiSubSystemBombLauncher","Weapon_R","Weapon_R");
-addShield(NewShipType,"EMP",200,16);
+addShield(NewShipType,"EMP",190,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=2
 NewShipType.sobSpecialDieTime=2

--- a/ship/hgn_attackbomberelite/hgn_attackbomberelite.ship
+++ b/ship/hgn_attackbomberelite/hgn_attackbomberelite.ship
@@ -155,7 +155,7 @@ StartShipWeaponConfig(NewShipType,"Hgn_AntiShipBombLauncher","Weapon_L","Weapon_
 StartShipWeaponConfig(NewShipType,"Hgn_AntiShipBombLauncher","Weapon_R","Weapon_R");
 StartShipWeaponConfig(NewShipType,"Hgn_AntiSubSystemBombLauncher","Weapon_L","Weapon_L");
 StartShipWeaponConfig(NewShipType,"Hgn_AntiSubSystemBombLauncher","Weapon_R","Weapon_R");
-addShield(NewShipType,"EMP",310,20);
+addShield(NewShipType,"EMP",310,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=0.1
 NewShipType.sobSpecialDieTime=2

--- a/ship/hgn_interceptor/hgn_interceptor.ship
+++ b/ship/hgn_interceptor/hgn_interceptor.ship
@@ -166,7 +166,7 @@ addAbility(NewShipType,"RetireAbility",1,0);
 addCustomCode(NewShipType, "data:ship/Hgn_Interceptor/Hgn_Interceptor.lua", "", "", "Update_Hgn_Interceptor", "", "Hgn_Interceptor", 0.7)
 LoadModel(NewShipType,1);
 StartShipWeaponConfig(NewShipType,"Hgn_KineticAutoGun","Weapon_FrontGun","Fire");
-addShield(NewShipType,"EMP",200,16);
+addShield(NewShipType,"EMP",190,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=2
 NewShipType.sobSpecialDieTime=2

--- a/ship/vgr_bomber/vgr_bomber.ship
+++ b/ship/vgr_bomber/vgr_bomber.ship
@@ -175,7 +175,7 @@ StartShipWeaponConfig(NewShipType,"Vgr_AntiShipBombLauncher","Weapon_L","Weapon_
 StartShipWeaponConfig(NewShipType,"Vgr_AntiShipBombLauncher","Weapon_R","Weapon_R");
 StartShipWeaponConfig(NewShipType,"Vgr_AntiSubSystemBombLauncher","Weapon_L","Weapon_L");
 StartShipWeaponConfig(NewShipType,"Vgr_AntiSubSystemBombLauncher","Weapon_R","Weapon_R");
-addShield(NewShipType,"EMP",200,16);
+addShield(NewShipType,"EMP",190,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=2
 NewShipType.sobSpecialDieTime=2

--- a/ship/vgr_interceptor/vgr_interceptor.ship
+++ b/ship/vgr_interceptor/vgr_interceptor.ship
@@ -168,7 +168,7 @@ addAbility(NewShipType,"RetireAbility",1,0);
 addCustomCode(NewShipType, "data:ship/Vgr_Interceptor/Vgr_Interceptor.lua", "", "", "Update_Vgr_Interceptor", "", "Vgr_Interceptor", 0.7)
 LoadModel(NewShipType,1);
 StartShipWeaponConfig(NewShipType,"Vgr_FlechetteCannon","Weapon_LongGun","Weapon_LongGun");
-addShield(NewShipType,"EMP",200,16);
+addShield(NewShipType,"EMP",190,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=2
 NewShipType.sobSpecialDieTime=2

--- a/ship/vgr_lancefighter/vgr_lancefighter.ship
+++ b/ship/vgr_lancefighter/vgr_lancefighter.ship
@@ -167,7 +167,7 @@ addAbility(NewShipType,"RetireAbility",1,0);
 addCustomCode(NewShipType, "data:ship/Vgr_LanceFighter/Vgr_LanceFighter.lua", "", "", "Update_Vgr_Lance_Fighter", "", "Vgr_LanceFighter", 0.7)
 LoadModel(NewShipType,1);
 StartShipWeaponConfig(NewShipType,"Vgr_LightPlasmaLance","Weapon_BigGun","Weapon_BigGun");
-addShield(NewShipType,"EMP",200,16);
+addShield(NewShipType,"EMP",190,17);
 NewShipType.battleScarCoverage=0
 NewShipType.sobDieTime=2
 NewShipType.sobSpecialDieTime=2


### PR DESCRIPTION
# EMP Tweaks Round 2

Before the recent change in b19, fighters had `110` emp health with a `20s` regen time

- fighter emp health `200 -> 190`
- health regen time: `16s -> 17s`