### PR TITLE
missile retargeting: cant fix; just reduce the damage a bunch

### DIFF
--- a/weapon/vgr_heavyfusionmissilelauncher/vgr_heavyfusionmissilelauncher.wepn
+++ b/weapon/vgr_heavyfusionmissilelauncher/vgr_heavyfusionmissilelauncher.wepn
@@ -2,6 +2,10 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Vgr_MediumMissile","Normal",40,3750,0,0,0,2,1,0,1,16,0,0,0,0,0,0,0.1,"Normal",0,1,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",2700,2700,"");
 setPenetration(NewWeaponType,35,1,
+{Unarmoured=0.01}, -- 2700 * 0.01 = 27 vs fighters
+{Unarmoured_hw1=0.01},
+{LightArmour=0.1},
+{LightArmour_hw1=0.1}, -- 2700 * 0.1 = 270 vs corvettes (ref: pulsar base HP is [480, 720])
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.10},
 {SpaceMineArmor=1},

--- a/weapon/vgr_heavyfusionmissilelauncherbc/vgr_heavyfusionmissilelauncherbc.wepn
+++ b/weapon/vgr_heavyfusionmissilelauncherbc/vgr_heavyfusionmissilelauncherbc.wepn
@@ -1,6 +1,10 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Vgr_HeavyMissile","Normal",40,5500,0,0,0,0,1,0,1,25,0,0,1,1,0,0,0.1,"Normal",0,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",5000,5000,"");
 setPenetration(NewWeaponType,75,1,
+{Unarmoured=0.01}, -- 5000 * 0.01 = 50 vs fighters
+{Unarmoured_hw1=0.01},
+{LightArmour=0.1},
+{LightArmour_hw1=0.1}, -- 5000 * 0.1 = 500 vs corvettes (ref: pulsar base HP is [480, 720])
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.10},
 {SpaceMineArmor=1},

--- a/weapon/vgr_heavyfusionmissilelauncherweak/vgr_heavyfusionmissilelauncherweak.wepn
+++ b/weapon/vgr_heavyfusionmissilelauncherweak/vgr_heavyfusionmissilelauncherweak.wepn
@@ -2,6 +2,10 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Vgr_HeavyMissile","Normal",40,4500,0,0,0,0,1,0,0,20,0,0,1,1,0,0,0.1,"Normal",0,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",2700,2700,"");
 setPenetration(NewWeaponType,20,1,
+{Unarmoured=0.01}, -- 2700 * 0.01 = 27 vs fighters
+{Unarmoured_hw1=0.01},
+{LightArmour=0.1},
+{LightArmour_hw1=0.1}, -- 2700 * 0.1 = 270 vs corvettes (ref: pulsar base HP is [480, 720])
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.10},
 {SpaceMineArmor=1},


### PR DESCRIPTION
- vgr HMF, DD, and BC missiles will do about half hp to vettes and fighters