### PR TITLE
Gunships

### DIFF
--- a/ship/hgn_assaultcorvette/hgn_assaultcorvette.ship
+++ b/ship/hgn_assaultcorvette/hgn_assaultcorvette.ship
@@ -1,7 +1,7 @@
 NewShipType = StartShipConfig()
 NewShipType.displayedName="$1506"
 NewShipType.sobDescription="$1507"
-NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 500)
+NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 510)
 NewShipType.regentime=0
 NewShipType.minRegenTime=0
 NewShipType.sideArmourDamage = getShipNum(NewShipType, "sideArmourDamage", 1.0)

--- a/ship/hgn_assaultcorvette/hgn_assaultcorvette.ship
+++ b/ship/hgn_assaultcorvette/hgn_assaultcorvette.ship
@@ -1,7 +1,7 @@
 NewShipType = StartShipConfig()
 NewShipType.displayedName="$1506"
 NewShipType.sobDescription="$1507"
-NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 490)
+NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 500)
 NewShipType.regentime=0
 NewShipType.minRegenTime=0
 NewShipType.sideArmourDamage = getShipNum(NewShipType, "sideArmourDamage", 1.0)

--- a/weapon/hgn_vulcankineticturret/hgn_vulcankineticturret.wepn
+++ b/weapon/hgn_vulcankineticturret/hgn_vulcankineticturret.wepn
@@ -9,16 +9,16 @@ setPenetration(NewWeaponType,5,1,
 {TorpedoArmor=0},
 {HeavyMissileArmor=0},
 {SmallMissileArmor=0},
-{LightArmour=0.65},
-{LightArmour_hw1=0.65},
-{MediumArmour=0.525},
+{LightArmour=0.55},
+{LightArmour_hw1=0.6},
+{MediumArmour=0.4},
 {SuperUtilityArmour = 0.85},
-{HeavyArmour=0.70},
-{DestroyerArmour = 0.70},
-{ResArmour=0.50});
+{HeavyArmour=0.60},
+{DestroyerArmour = 0.6},
+{ResArmour=0.55});
 setAccuracy(NewWeaponType,1,
-{Swarmer=0.01},
-{SpaceMine=0.01},
+{Swarmer=0.7},
+{SpaceMine=0.8},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
@@ -28,16 +28,15 @@ setAccuracy(NewWeaponType,1,
 {Corvette_hw1=0.40},
 {munition=0.20},
 {Frigate=0.60},
-{SmallCapitalShip=0.60},
-{BigCapitalShip=0.60},
-{ResourceLarge=0.50});
+{SmallCapitalShip=0.80},
+{BigCapitalShip=0.90},
+{ResourceLarge=0.8});
 setAngles(NewWeaponType,5,-180,180,-12,75);
 setMiscValues(NewWeaponType,1.5,0.5);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setMissProperties(NewWeaponType, 0.02, 0.04, 0.20, 0.35, 0.55, 0.65);
 setLifetimeMult(NewWeaponType, 1.65);
 setDamageFalloff(NewWeaponType, 0.15/1600.0, 0.1);
-setAccuracyFalloff(NewWeaponType, 0.15/1600.0, 0.1);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.3, 300, 1.0, 390, 1.0, 487, 1.03, 535, 1.6);
 setBallistics(NewWeaponType,0,1.0);
 setFireMultFactor(NewWeaponType, 1.0);


### PR DESCRIPTION
# Gunships

## Unit

- base HP: `490 -> 510`; to somewhat offset the incoming buff to [int vs corvette damage](https://github.com/Novaras/2.3-Test/pull/18)

## Weapon

### Damage Mults

just to ensure the HP buff doesnt mean gunships can fight non fighters

- vs hw2 vettes `0.65 -> 0.55`
- vs hw1 vettes `0.65 -> 0.6`
- vs frigates: `0.525 -> 0.4`

### Accuracy

allow them to hit mines, the rest is just makes sense

- vs mines: `0.01 -> 0.8`
- vs destroyers: `0.6 -> 0.8`
- vs supercaps (bc, motherships...): `0.6 -> 0.9`
- vs carriers and refs: `0.5 -> 0.8`