### PR TITLE
Vaygr Assault Frigate Weapons

### DIFF
--- a/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
@@ -15,7 +15,7 @@ setPenetration(NewWeaponType,5,1,
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.3},
+{SpaceMine=0.7},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},

--- a/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
@@ -2,39 +2,42 @@ StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","Kinetic_Small","Norma
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",95,95,"");
 setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
-{Unarmoured_hw1=1.0},
-{LightArmour=1.0*1.114},
-{LightArmour_hw1=1.7},
+{Unarmoured_hw1=0.7},
+{LightArmour=0.3},
+{LightArmour_hw1=0.5},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
 {DestroyerArmour = 0.82},
-{ResArmour=0.60},
+{ResArmour=0.50},
 {PlanetKillerArmour=0},
-{SwarmerArmor=0.10},
+{SwarmerArmor=0.50},
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.2},
+{SpaceMine=0.3},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
-{Fighter=0.72},
-{Fighter_hw1=0.8},
-{Corvette=0.25},
-{Corvette_hw1=0.3},
+{Fighter=0.4},
+{Fighter_hw1=0.4},
+{Corvette=0.5},
+{Corvette_hw1=0.6},
 {munition=0.1},
-{Frigate=0.8},
-{SmallCapitalShip=0.8},
-{BigCapitalShip=0.8},
-{ResourceLarge=0.6});
+{Frigate=0.85},
+{SmallCapitalShip=0.9},
+{BigCapitalShip=0.99},
+{ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-150,150,-10,60);
 setMiscValues(NewWeaponType,1.5,0);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setDamageFalloff(NewWeaponType, 0.15/2500.0, 0.1);
-setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
 setMissProperties(NewWeaponType, 0.02, 0.03, 0.25, 0.35, 0.55, 0.55);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 487, 1.2, 535, 4.0);
 setLifetimeMult(NewWeaponType, 1.77);
-setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);
+
+-- setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
+
+setMissileKiller(NewWeaponType,1);
+setBallistics(NewWeaponType,1,0);

--- a/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigatebottom/vgr_flechettecannonassaultfrigatebottom.wepn
@@ -4,7 +4,7 @@ setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
 {Unarmoured_hw1=0.7},
 {LightArmour=0.3},
-{LightArmour_hw1=0.5},
+{LightArmour_hw1=0.6},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
@@ -27,6 +27,7 @@ setAccuracy(NewWeaponType,1,
 {Frigate=0.85},
 {SmallCapitalShip=0.9},
 {BigCapitalShip=0.99},
+{Resource=0.8},
 {ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-150,150,-10,60);
 setMiscValues(NewWeaponType,1.5,0);

--- a/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
@@ -15,7 +15,7 @@ setPenetration(NewWeaponType,5,1,
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.3},
+{SpaceMine=0.7},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},

--- a/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
@@ -4,7 +4,7 @@ setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
 {Unarmoured_hw1=0.7},
 {LightArmour=0.3},
-{LightArmour_hw1=0.5},
+{LightArmour_hw1=0.6},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
@@ -27,6 +27,7 @@ setAccuracy(NewWeaponType,1,
 {Frigate=0.85},
 {SmallCapitalShip=0.9},
 {BigCapitalShip=0.99},
+{Resource=0.8},
 {ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-180,13,-10,60);
 setMiscValues(NewWeaponType,1.5,0);

--- a/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateleft/vgr_flechettecannonassaultfrigateleft.wepn
@@ -2,39 +2,41 @@ StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","Kinetic_Small","Norma
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",95,95,"");
 setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
-{Unarmoured_hw1=1.0},
-{LightArmour=1.0*1.114},
-{LightArmour_hw1=1.7},
+{Unarmoured_hw1=0.7},
+{LightArmour=0.3},
+{LightArmour_hw1=0.5},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
 {DestroyerArmour = 0.82},
-{ResArmour=0.60},
+{ResArmour=0.50},
 {PlanetKillerArmour=0},
-{SwarmerArmor=0.10},
+{SwarmerArmor=0.50},
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.2},
+{SpaceMine=0.3},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
-{Fighter=0.72},
-{Fighter_hw1=0.8},
-{Corvette=0.25},
-{Corvette_hw1=0.3},
+{Fighter=0.4},
+{Fighter_hw1=0.4},
+{Corvette=0.5},
+{Corvette_hw1=0.6},
 {munition=0.1},
-{Frigate=0.8},
-{SmallCapitalShip=0.8},
-{BigCapitalShip=0.8},
-{ResourceLarge=0.6});
+{Frigate=0.85},
+{SmallCapitalShip=0.9},
+{BigCapitalShip=0.99},
+{ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-180,13,-10,60);
 setMiscValues(NewWeaponType,1.5,0);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setDamageFalloff(NewWeaponType, 0.15/2500.0, 0.1);
-setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
 setMissProperties(NewWeaponType, 0.02, 0.03, 0.25, 0.35, 0.55, 0.55);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 487, 1.2, 535, 4.0);
 setLifetimeMult(NewWeaponType, 1.77);
-setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);
+
+-- setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
+setMissileKiller(NewWeaponType,1);
+setBallistics(NewWeaponType,1,0);

--- a/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
@@ -15,7 +15,7 @@ setPenetration(NewWeaponType,5,1,
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.3},
+{SpaceMine=0.7},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},

--- a/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
@@ -2,39 +2,42 @@ StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","Kinetic_Small","Norma
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",95,95,"");
 setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
-{Unarmoured_hw1=1.0},
-{LightArmour=1.0*1.114},
-{LightArmour_hw1=1.7},
+{Unarmoured_hw1=0.7},
+{LightArmour=0.3},
+{LightArmour_hw1=0.5},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
 {DestroyerArmour = 0.82},
-{ResArmour=0.60},
+{ResArmour=0.50},
 {PlanetKillerArmour=0},
-{SwarmerArmor=0.10},
+{SwarmerArmor=0.50},
 {SpaceMineArmor=1});
 setAccuracy(NewWeaponType,1,
 {Swarmer=0.8},
-{SpaceMine=0.2},
+{SpaceMine=0.3},
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
-{Fighter=0.72},
-{Fighter_hw1=0.8},
-{Corvette=0.25},
-{Corvette_hw1=0.3},
+{Fighter=0.4},
+{Fighter_hw1=0.4},
+{Corvette=0.5},
+{Corvette_hw1=0.6},
 {munition=0.1},
-{Frigate=0.8},
-{SmallCapitalShip=0.8},
-{BigCapitalShip=0.8},
-{ResourceLarge=0.6});
+{Frigate=0.85},
+{SmallCapitalShip=0.9},
+{BigCapitalShip=0.99},
+{ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-13,180,-10,60);
 setMiscValues(NewWeaponType,1.5,0);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setDamageFalloff(NewWeaponType, 0.15/2500.0, 0.1);
-setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
 setMissProperties(NewWeaponType, 0.02, 0.03, 0.25, 0.35, 0.55, 0.55);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 487, 1.2, 535, 4.0);
 setLifetimeMult(NewWeaponType, 1.77);
-setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);
+
+-- setAccuracyFalloff(NewWeaponType, 0.15/2500.0, 0.1);
+
+setMissileKiller(NewWeaponType,1);
+setBallistics(NewWeaponType,1,0);

--- a/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
+++ b/weapon/vgr_flechettecannonassaultfrigateright/vgr_flechettecannonassaultfrigateright.wepn
@@ -4,7 +4,7 @@ setPenetration(NewWeaponType,5,1,
 {Unarmoured=0.50},
 {Unarmoured_hw1=0.7},
 {LightArmour=0.3},
-{LightArmour_hw1=0.5},
+{LightArmour_hw1=0.6},
 {MediumArmour=1.0},
 {SuperUtilityArmour = 1.0},
 {HeavyArmour=0.82},
@@ -27,6 +27,7 @@ setAccuracy(NewWeaponType,1,
 {Frigate=0.85},
 {SmallCapitalShip=0.9},
 {BigCapitalShip=0.99},
+{Resource=0.8},
 {ResourceLarge=0.85});
 setAngles(NewWeaponType,0,-13,180,-10,60);
 setMiscValues(NewWeaponType,1.5,0);


### PR DESCRIPTION
# Vaygr Assault Frigate

## Weapons

All three weapons are identical, except they have different turret angles.

- Removed accuracy falloff over distance; the weapon is consistent across all ranges
- **Removed ballistics**. Now a pure accuracy % based weapon, this was the easiest way to make the weapon much much more reliable and easy to tune. Ballistic aiming in HWRM is fine in some situations, but here it was making it exceptionally difficult to make assault frigates consistent across all ranges and situations. For example, **the weapons are now unusually good at sniping low HP squads at long range**, as they perform the same vs close and far targets, and vs those flying fast or changing direction.
- Can now shoot & kill mines (use force attack); as a non-ballistic weapon you can shoot incoming mines reliably
  - previously unused accuracy `0.2 -> 0.7`

### Damage Mults

- vs collectors `0.6 -> 0.5`

The following multipliers were set to balance the weapons new % based accuracy making it much more reliable. Ballistic weapons are typically overpowered to compensate for their inability to land shots in many situations; this is especially true vs HW1 strike units. There are situations where a ballistic weapon simply cannot land its shots, i.e if a distant unit is changing direction.

As non-ballistic weapons, these guns are now focused on constant DPS as opposed to suddenly dealing huge burst damage if the target is too close or accidentally stops moving laterally from the weapons perspective.

- vs hw1 fighters: `1.0 -> 0.7`
- vs hw2 vettes: `1.114 -> 0.3`
- vs hw1 vettes: `1.7 -> 0.6`

### Accuracy

- vs hw2 fighters: `0.72 -> 0.4`
- vs hw1 fighters: `0.8 -> 0.4`
- vs hw2 vettes: `0.25 -> 0.5`
- vs hw1 vettes: `0.3 -> 0.6`
- vs frigates: `0.8 -> 0.85`
- vs small caps i.e destroyers: `0.8 -> 0.9`
- vs big caps i.e bcs, motherships: `0.8 -> 0.99`
- vs refineries etc: `0.6 -> 0.85`